### PR TITLE
MDEXP-529 Upgrade folio-spring-base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			${project.basedir}/src/main/resources/swagger.api/transformation-fields.yaml
 		</transformation-fields.yaml.file>
 
-		<folio-spring-base.version>3.0.1</folio-spring-base.version>
+		<folio-spring-base.version>3.0.3</folio-spring-base.version>
 		<lombok.version>1.18.18</lombok.version>
 		<log4j2.version>2.17.2</log4j2.version>
 		<openapi-generator.version>4.3.1</openapi-generator.version>


### PR DESCRIPTION
[MDEXP-529](https://issues.folio.org/browse/MDEXP-529) - Spring4Shell mod-data-export-spring-migrated (CVE-2022-22965)