### PR TITLE
MDEXP-529 - Spring4Shell mod-data-export-spring-migrated (CVE-2022-22965)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.6</version>
+		<version>2.7.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
[MDEXP-529](https://issues.folio.org/browse/MDEXP-529) - Spring4Shell mod-data-export-spring-migrated (CVE-2022-22965)

* Updated spring-boot-starter-parent to version 2.7.0