### PR TITLE
MODEXPS-174: postgresql 42.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<lombok.version>1.18.18</lombok.version>
 		<log4j2.version>2.17.2</log4j2.version>
 		<openapi-generator.version>4.3.1</openapi-generator.version>
+		<postgresql.version>42.5.0</postgresql.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Upgrading postgresql from 42.3.3 to 42.5.0 fixes this SQL Injection vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-31197